### PR TITLE
fix: fixed hook timing

### DIFF
--- a/EntWatchSharp/EntWatchSharp.cs
+++ b/EntWatchSharp/EntWatchSharp.cs
@@ -92,7 +92,10 @@ namespace EntWatchSharp
 			EW.g_TimerUnban = new CounterStrikeSharp.API.Modules.Timers.Timer(60.0f, TimerUnban, TimerFlags.REPEAT);
 
 			RegEvents();
-			VirtualFunctionsInitialize();
+			RegisterListener<Listeners.OnMetamodAllPluginsLoaded>(() =>
+			{
+				VirtualFunctionsInitialize();
+			});
 			EbanDB.Init_DB(ModuleDirectory);
 			LogManager.LoadConfig(ModuleDirectory);
 			UI.EWSysInfo("Info.EWLoaded", 6);


### PR DESCRIPTION
tested: Linux x64, latest cs2fixes + latest CS#(318)
Changed to wait for cs2fixes hook processing before calling `VirtualFunctionsInitialize`.
This allows it to be used with cs2fixes' ZR mode :D